### PR TITLE
Fix category article fat datatransfer

### DIFF
--- a/models/dbgateways/oevattbecategoryvatgroupspopulatordbgateway.php
+++ b/models/dbgateways/oevattbecategoryvatgroupspopulatordbgateway.php
@@ -89,7 +89,7 @@ class oeVATTBECategoryVATGroupsPopulatorDbGateway
         $oDb = $this->_getDb();
 
         $sSql = 'INSERT INTO `oevattbe_articlevat` (`oevattbe_articleid`, `oevattbe_countryid`, `oevattbe_vatgroupid`)
-              SELECT `oxobject2category`.`oxobjectid`, `oevattbe_categoryvat`.`oevattbe_countryid`, `oevattbe_categoryvat`.`oevattbe_vatgroupid`
+              SELECT DISTINCT `oxobject2category`.`oxobjectid`, `oevattbe_categoryvat`.`oevattbe_countryid`, `oevattbe_categoryvat`.`oevattbe_vatgroupid`
               FROM `oxobject2category`
               LEFT JOIN `oevattbe_categoryvat` ON `oxobject2category`.`oxcatnid` = `oevattbe_categoryvat`.`oevattbe_categoryid`
               WHERE `oevattbe_categoryvat`.`oevattbe_categoryid` = '. $oDb->quote($sCategoryId);


### PR DESCRIPTION
The SQL to field the table `oevattbe_articlevat` has a bug, that can lied to duplicate entries and causes a MYSQL error. Adding DISTINCT will avoid duplicate entries.
